### PR TITLE
Move nested list and tuple handling to a separate function

### DIFF
--- a/tinytools/bunch.py
+++ b/tinytools/bunch.py
@@ -97,22 +97,62 @@ class OrderedBunch(_collections.OrderedDict):
 def ordered_bunchify(x,level=0):
     """ Recursively transforms a dictionary into a OrderedBunch via copy.
     """
+
+    # if x == [[[1, 2], [3, 4]]]:
+    #     import ipdb; ipdb.set_trace()
+
     speak = False
     if speak: print '*'*(level+1)+' x is:  '+str(x)
     if isinstance(x, dict):
         return OrderedBunch((k, ordered_bunchify(v)) for k,v in x.iteritems())
+#    # elif isinstance(x, (list, tuple)):
+        # y = list(x)
+        # for i,v in enumerate(y):
+        #     y[i] = ordered_bunchify(y[i],level=level+1)
+        # if speak: print '*'*(level+1)+' OrderedBunch request is:  '+repr(y)
+        # try:
+        #     out = OrderedBunch(y)
+        #     if isinstance(y[0],str):
+        #         raise ValueError("This catches when the OrderedDict " \
+        #                          "(underneath OrderedBunch) broadcasts" \
+        #                          "a single key to mutiple dict entries.  See" \
+        #                          "unittests 'nested_bunches'.")
+        #     if speak: print '*'*(level+1)+ 'Bunchify worked, out is:  '+str(out)
+        #     return out
+        # except Exception as e:
+        #     print('the error is:')
+        #     print(e)
+        #     if speak: print '*'*(level+1)+' exception raised, out is:  '+str(y)
+        #     return y
+    else:
+        return x
+
+def ordered_dictionarify(x,level=0):
+    """Take a crack at parsing lists of lists or tuples of tuples into nested
+    ordered dictionaries.  This can be coupled with ordered_bunchify to
+    create nested ordered bunches from non-dictionary input."""
+    speak = False
+    if speak: print '*' * (level + 1) + ' x is:  ' + str(x)
+    if isinstance(x, dict):
+        return _collections.OrderedDict((k, ordered_dictionarify(v)) for k, v in x.iteritems())
     elif isinstance(x, (list, tuple)):
         y = list(x)
         for i,v in enumerate(y):
-            y[i] = ordered_bunchify(y[i],level=level+1)
+            y[i] = ordered_dictionarify(y[i],level=level+1)
         if speak: print '*'*(level+1)+' OrderedBunch request is:  '+repr(y)
         try:
-            out = OrderedBunch(y)
+            out = _collections.OrderedDict(y)
             if isinstance(y[0],str):
                 raise ValueError("This catches when the OrderedDict " \
                                  "(underneath OrderedBunch) broadcasts" \
                                  "a single key to mutiple dict entries.  See" \
                                  "unittests 'nested_bunches'.")
+            if any([isinstance(x,int) for x in out.keys()]) or \
+                any([isinstance(x,float) for x in out.keys()]):
+                raise ValueError('This catches when using passing floats or '
+                                 'strings as dictionary keys.  You should '
+                                 'pass on the dictionarify function if that is'
+                                 'really what you want.')
             if speak: print '*'*(level+1)+ 'Bunchify worked, out is:  '+str(out)
             return out
         except:
@@ -143,7 +183,7 @@ def _print_recursive_start(x):
     take care of formatting for the print'''
     try:
         if not isinstance(x,OrderedBunch):
-            ob = ordered_bunchify(x)
+            ob = ordered_bunchify(ordered_dictionarify(x))
         else:
             ob = x
     except:

--- a/tinytools/tests/test_tinytools.py
+++ b/tinytools/tests/test_tinytools.py
@@ -545,11 +545,24 @@ class TestBunch(unittest.TestCase):
                                        ['bb', 1.23],
                                        ['cc',['mul2']]]]])
 
+        self.dicts4 = []
+        self.dicts4.append(collections.OrderedDict({'a':[[[1,2],[3,4]]]}))
+
+    def test_lists_of_list_length_one(self):
+        for li,lv in enumerate(self.dicts4):
+            din = self.dicts4[li]
+            ob = ordered_bunchify(ordered_dictionarify(din))
+            print(repr(ob))
+
+            a = isinstance(ob,OrderedBunch)
+            b = isinstance(ob[ob.keys()[0]],list)
+
+            self.assertTrue(a & b)
 
     def test_nested_lists(self):
         for li,lv in enumerate(self.dicts2):
             din = self.dicts2[li]
-            ob = ordered_bunchify(din)
+            ob = ordered_bunchify(ordered_dictionarify(din))
             print(repr(ob))
 
             a = isinstance(ob,OrderedBunch)
@@ -561,7 +574,7 @@ class TestBunch(unittest.TestCase):
     def test_nested_bunches(self):
         for li,lv in enumerate(self.dicts3):
             din = self.dicts3[li]
-            ob = ordered_bunchify(din)
+            ob = ordered_bunchify(ordered_dictionarify(din))
             print(repr(ob))
 
             a = isinstance(ob,OrderedBunch)
@@ -572,7 +585,7 @@ class TestBunch(unittest.TestCase):
 
     def test_ordered_bunchify_list_of_strings(self):
         li = 7
-        ob = ordered_bunchify(self.dicts[li])
+        ob = ordered_bunchify(ordered_dictionarify(self.dicts[li]))
         print(repr(ob))
         a = isinstance(ob,OrderedBunch)
         b = isinstance(ob['aaa'],list)
@@ -582,7 +595,7 @@ class TestBunch(unittest.TestCase):
 
     def test_ordered_bunchify_dictsliststuples(self):
         for li in [0,1,2,3,4]:
-            ob = ordered_bunchify(self.dicts[li])
+            ob = ordered_bunchify(ordered_dictionarify(self.dicts[li]))
             print(repr(ob))
             a = isinstance(ob,OrderedBunch)
             b = isinstance(ob['c'],OrderedBunch)
@@ -591,7 +604,7 @@ class TestBunch(unittest.TestCase):
 
     def test_ordered_bunchify_nested_tuples_and_lists(self):
         li = 5
-        ob = ordered_bunchify(self.dicts[li])
+        ob = ordered_bunchify(ordered_dictionarify(self.dicts[li]))
         print(repr(ob))
         a = isinstance(ob,OrderedBunch)
         b = isinstance(ob['c'],OrderedBunch)
@@ -602,7 +615,7 @@ class TestBunch(unittest.TestCase):
 
     def test_ordered_bunchify_len2tuples_and_lists(self):
         li = 6
-        ob = ordered_bunchify(self.dicts[li])
+        ob = ordered_bunchify(ordered_dictionarify(self.dicts[li]))
         print(repr(ob))
         a = isinstance(ob,OrderedBunch)
         b = isinstance(ob['c'],OrderedBunch)
@@ -613,7 +626,7 @@ class TestBunch(unittest.TestCase):
 
     def test_ordered_bunchify_dot_access(self):
         for li in xrange(7):
-            ob = ordered_bunchify(self.dicts[li])
+            ob = ordered_bunchify(ordered_dictionarify(self.dicts[li]))
             print(repr(ob))
             a = ob.a=='one'
             b = ob.c.aa==1
@@ -621,7 +634,7 @@ class TestBunch(unittest.TestCase):
 
     def test_ordered_bunchify_dot_assign(self):
         for li in xrange(7):
-            ob = ordered_bunchify(self.dicts[li])
+            ob = ordered_bunchify(ordered_dictionarify(self.dicts[li]))
             print(repr(ob))
             ob.d='test'
             a = ob.d=='test'
@@ -635,7 +648,7 @@ class TestBunch(unittest.TestCase):
         otc2 = [tuple,tuple,list]
         for li in xrange(7):
             for x in xrange(len(oti)):
-                ob = ordered_bunchify(self.dicts[li])
+                ob = ordered_bunchify(ordered_dictionarify(self.dicts[li]))
                 out = ordered_unbunchify(ob,out_type=oti[x])
                 print(repr(ob))
                 print(repr(out))
@@ -656,27 +669,27 @@ class TestBunch(unittest.TestCase):
 
     def test_ob_print_recursive_ordered_bunch(self):
         for x in xrange(7):
-            ob = ordered_bunchify(self.dicts[x])
+            ob = ordered_bunchify(ordered_dictionarify(self.dicts[x]))
             self.assertTrue(len(tinytools.bunch._print_recursive_start(ob).split('\n'))==6)
 
     def test_ob_print_recursive_ordered_unbunch_type0(self):
         for x in xrange(7):
             d = self.dicts[x]
-            ob = ordered_bunchify(self.dicts[x])
+            ob = ordered_bunchify(ordered_dictionarify(self.dicts[x]))
             out = ordered_unbunchify(ob,out_type=0)
             self.assertTrue(len(tinytools.bunch._print_recursive_start(out).split('\n'))==6)
 
     def test_ob_print_recursive_ordered_unbunch_type1(self):
         for x in xrange(7):
             d = self.dicts[x]
-            ob = ordered_bunchify(self.dicts[x])
+            ob = ordered_bunchify(ordered_dictionarify(self.dicts[x]))
             out = ordered_unbunchify(ob,out_type=1)
             self.assertTrue(len(tinytools.bunch._print_recursive_start(out).split('\n'))==6)
 
     def test_ob_print_recursive_ordered_unbunch_type2(self):
         for x in xrange(7):
             d = self.dicts[x]
-            ob = ordered_bunchify(self.dicts[x])
+            ob = ordered_bunchify(ordered_dictionarify(self.dicts[x]))
             out = ordered_unbunchify(ob,out_type=2)
             self.assertTrue(len(tinytools.bunch._print_recursive_start(out).split('\n'))==6)
 


### PR DESCRIPTION
Changes allow dictionary nesting to happen outside bunchify to more cleanly handle the case of multiple nested single lists.  bunch currently tried to handle nested lists and tuples, but it is very tricky and not totally deterministic so it is better to have the capability pulled outside the core functionality.  Handling of nested lists and tuples should probably just be moved or removed in the future.
